### PR TITLE
#100 Update Bielik model to v2.3 and adjust related documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.5.11 (2025-03-16)
+
+- Updated Bielik model from v2.2 to v2.3.
+
 ## 2.5.10 (2025-03-06)
 
 - Added a new model: Claude 3.7 Sonnet.  

--- a/README.md
+++ b/README.md
@@ -905,9 +905,9 @@ The name of the currently active profile is shown as (Profile Name) in the windo
 
 ## Built-in models
 
-PyGPT has built-in support for models (as of 2024-11-27):
+PyGPT has built-in support for models (as of 2025-03-16):
 
-- ``bielik-11b-v2.3-instruct:Q4_K_M``
+- `bielik-11b-v2.3-instruct:Q4_K_M`
 - `chatgpt-4o-latest`
 - `claude-3-5-sonnet-20240620`
 - `claude-3-opus-20240229`

--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ The name of the currently active profile is shown as (Profile Name) in the windo
 
 PyGPT has built-in support for models (as of 2024-11-27):
 
-- `bielik-11b-v2.2-instruct:Q4_K_M`
+- ``bielik-11b-v2.3-instruct:Q4_K_M``
 - `chatgpt-4o-latest`
 - `claude-3-5-sonnet-20240620`
 - `claude-3-opus-20240229`

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -4,7 +4,7 @@ Models
 Built-in models
 ---------------
 
-PyGPT has built-in support for models (as of 2024-11-27):
+PyGPT has built-in support for models (as of 2025-03-16):
 
 * ``bielik-11b-v2.2-instruct:Q4_K_M``
 * ``chatgpt-4o-latest``

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -6,7 +6,7 @@ Built-in models
 
 PyGPT has built-in support for models (as of 2025-03-16):
 
-* ``bielik-11b-v2.2-instruct:Q4_K_M``
+* ``bielik-11b-v2.3-instruct:Q4_K_M``
 * ``chatgpt-4o-latest``
 * ``claude-3-5-sonnet-20240620``
 * ``claude-3-opus-20240229``

--- a/src/pygpt_net/data/config/models.json
+++ b/src/pygpt_net/data/config/models.json
@@ -3016,8 +3016,8 @@
                 "reasoning_effort": "high"
             }
         },
-        "bielik-11b-v2.2-instruct:Q4_K_M": {
-            "id": "SpeakLeash/bielik-11b-v2.2-instruct:Q4_K_M",
+        "bielik-11b-v2.3-instruct:Q4_K_M": {
+            "id": "SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M",
             "name": "bielik-11b-v2.2",
             "mode": [
                 "llama_index",
@@ -3034,7 +3034,7 @@
                 "args": [
                     {
                         "name": "model",
-                        "value": "SpeakLeash/bielik-11b-v2.2-instruct:Q4_K_M",
+                        "value": "SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M",
                         "type": "str"
                     }
                 ],
@@ -3048,7 +3048,7 @@
                 "args": [
                     {
                         "name": "model",
-                        "value": "SpeakLeash/bielik-11b-v2.2-instruct:Q4_K_M",
+                        "value": "SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M",
                         "type": "str"
                     }
                 ],

--- a/src/pygpt_net/provider/core/model/patch.py
+++ b/src/pygpt_net/provider/core/model/patch.py
@@ -515,6 +515,21 @@ class Patch:
                 # add claude-3-7-sonnet-latest
                 updated = True
 
+            # < 2.5.11  <--- update Bielik from v2.2 to v2.3
+            if old < parse_version("2.5.11"):
+                print("Migrating models from < 2.5.11...")
+                # Remove old Bielik v2.2 model if exists
+                if 'bielik-11b-v2.2-instruct:Q4_K_M' in data:
+                    # If we have the newer model with v2.3, keep its settings
+                    if 'SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M' not in data:
+                        # Copy the old model's data to the new model ID
+                        data['SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M'] = data['bielik-11b-v2.2-instruct:Q4_K_M']
+                        # Update ID and name for the new model
+                        data['SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M'].id = "SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M"
+                        data['SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M'].name = "bielik-11b-v2.3"
+                    del data['bielik-11b-v2.2-instruct:Q4_K_M']
+                updated = True
+
         # update file
         if updated:
             data = dict(sorted(data.items()))

--- a/src/pygpt_net/provider/core/model/patch.py
+++ b/src/pygpt_net/provider/core/model/patch.py
@@ -518,16 +518,7 @@ class Patch:
             # < 2.5.11  <--- update Bielik from v2.2 to v2.3
             if old < parse_version("2.5.11"):
                 print("Migrating models from < 2.5.11...")
-                # Remove old Bielik v2.2 model if exists
-                if 'bielik-11b-v2.2-instruct:Q4_K_M' in data:
-                    # If we have the newer model with v2.3, keep its settings
-                    if 'SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M' not in data:
-                        # Copy the old model's data to the new model ID
-                        data['SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M'] = data['bielik-11b-v2.2-instruct:Q4_K_M']
-                        # Update ID and name for the new model
-                        data['SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M'].id = "SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M"
-                        data['SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M'].name = "bielik-11b-v2.3"
-                    del data['bielik-11b-v2.2-instruct:Q4_K_M']
+                # update Bielik from v2.2 to v2.3
                 updated = True
 
         # update file


### PR DESCRIPTION
Added migration logic in patch.py for version 2.5.11 to update Bielik to SpeakLeash/bielik-11b-v2.3-instruct:Q4_K_M

I understand that if the models.json is updated then all we need is to bump up the version. Correct me please if I'm wrong

closes: #100 