### PR TITLE
fix: strip top_p and guard temperature for Claude 4.x Anthropic models

### DIFF
--- a/src/pygpt_net/provider/api/anthropic/chat.py
+++ b/src/pygpt_net/provider/api/anthropic/chat.py
@@ -102,10 +102,11 @@ class Chat:
         # Add optional fields only if provided
         if system_prompt:
             params["system"] = system_prompt  # SDK expects string or blocks, not None
-        if temperature is not None:
-            params["temperature"] = temperature  # keep as-is; upstream config controls the type
-        if top_p is not None:
-            params["top_p"] = top_p
+        # Claude 4.x: top_p is rejected when temperature is also present.
+        # Opus 4.x and claude-3-7-sonnet have deprecated temperature entirely (extended thinking).
+        _no_temp = ("claude-opus-4-", "claude-3-7-sonnet")
+        if temperature is not None and not any(model.id.startswith(p) for p in _no_temp):
+            params["temperature"] = temperature
         if tools:  # only include when non-empty list
             params["tools"] = tools  # must be a valid list per API
         if mcp_servers:


### PR DESCRIPTION
## Problem

PyGPT sends both `temperature` and `top_p` to the Anthropic API simultaneously. Claude 4.x models reject this combination with HTTP 400:

> `temperature and top_p cannot both be specified for this model`

Additionally, the entire **Opus 4.x** family (`claude-opus-4-0`, `claude-opus-4-5`, `claude-opus-4-7`, …) and **`claude-3-7-sonnet`** (extended-thinking models) have deprecated `temperature` entirely — any request that includes it returns HTTP 400:

> `` `temperature` is deprecated for this model ``

## Fix

In `src/pygpt_net/provider/api/anthropic/chat.py`, replace the unconditional `temperature` + `top_p` block with a model-aware version:

- **`top_p`** is never sent to Anthropic (always causes the error when `temperature` is also present)
- **`temperature`** is omitted for model IDs starting with `claude-opus-4-` or `claude-3-7-sonnet`; all other models keep their configured value

## Models tested

| Model | temperature | top_p |
|---|---|---|
| `claude-sonnet-4-5`, `claude-sonnet-4-6`, `claude-3-*` | ✅ sent | ❌ removed |
| `claude-opus-4-*`, `claude-3-7-sonnet-*` | ❌ removed | ❌ removed |

## Notes

The `_no_temp` prefix tuple can be extended as Anthropic deprecates `temperature` on further models.