### PR TITLE
Fix: use unique filename per xAI TTS generation to avoid Windows file…

### DIFF
--- a/src/pygpt_net/provider/audio_output/xai_tts.py
+++ b/src/pygpt_net/provider/audio_output/xai_tts.py
@@ -16,6 +16,8 @@ import os
 import queue
 import threading
 import wave
+import time
+import uuid
 from typing import Optional, Tuple
 
 from .base import BaseProvider
@@ -115,7 +117,9 @@ class XAITextToSpeech(BaseProvider):
 
         base_dir = self.plugin.window.core.config.path
         default_name = getattr(self.plugin, "output_file", "output.wav")
-        out_path = os.path.join(base_dir, default_name)
+        name_root, _ = os.path.splitext(default_name)
+        unique_name = f"{name_root}_{int(time.time() * 1000)}_{uuid.uuid4().hex[:8]}"
+        out_path = os.path.join(base_dir, unique_name)
         out_path = self._ensure_extension(out_path, ".wav" if container == "wav" else ".raw")
 
         result_queue: queue.Queue[Tuple[bool, Optional[str], Optional[bytes]]] = queue.Queue()


### PR DESCRIPTION
Fix: use unique filename per xAI TTS generation to avoid Windows file-lock PermissionError

Previously every xAI TTS call wrote to the same fixed filename (output.wav), which could still be locked by playback on Windows, causing a PermissionError on the second consecutive generation. This generates a unique filename per call instead, so writes never collide with a file still in use.

This fix was developed collaboratively with Claude (Anthropic), based on analysis of the traceback and source, and tested against the reported PermissionError on Windows before submission.