### PR TITLE
Remove ad banner from toolbox UI

### DIFF
--- a/src/pygpt_net/controller/launcher/launcher.py
+++ b/src/pygpt_net/controller/launcher/launcher.py
@@ -27,16 +27,12 @@ class Launcher:
 
     def post_setup(self):
         """Post setup launcher"""
-        # Check for updates first, then synchronize banners. Both operations
-        # are asynchronous and never block the UI thread.
+        # Check for updates. Asynchronous, never blocks the UI thread.
         if self.window.core.config.get('updater.check.launch'):
             self.window.core.updater.run_check(
                 force=True,
-                on_finished=self.window.core.banners.run_load,
                 event="launch",
             )
-        else:
-            self.window.core.banners.run_load()
 
     def show_api_monit(self):
         """Show empty API KEY monit"""

--- a/src/pygpt_net/ui/layout/toolbox/toolbox.py
+++ b/src/pygpt_net/ui/layout/toolbox/toolbox.py
@@ -16,7 +16,6 @@ from pygpt_net.ui.widget.element.labels import HelpLabel
 from pygpt_net.utils import trans
 
 from .assistants import Assistants
-from .banner import Banner
 from .indexes import Indexes
 from .mode import Mode
 from .model import Model
@@ -33,7 +32,6 @@ class ToolboxMain:
         """
         self.window = window
         self.assistants = Assistants(window)
-        self.banner = Banner(window)
         self.indexes = Indexes(window)
         self.footer = Footer(window)
         self.mode = Mode(window)
@@ -59,7 +57,6 @@ class ToolboxMain:
         # presets / assistants
         toolbox_mode = QWidget(self.window)
         layout = QVBoxLayout(toolbox_mode)
-        layout.addWidget(self.banner.setup(), alignment=Qt.AlignTop | Qt.AlignRight)  # banner
         layout.addWidget(self.mode.setup())  # modes
         layout.addWidget(self.model.setup())  # models
         layout.addWidget(tip)


### PR DESCRIPTION
## Summary
- Stop creating/showing the `BannerWidget` in the toolbox layout
- Stop fetching remote banner data (`core.banners.run_load()`) on startup

## Test plan
- [x] Launched the app locally and confirmed no banner appears in the toolbox
- [x] Confirmed no errors in startup logs