### PR TITLE
fix(remote_store): after_update hook silently never runs (TypeError swallowed by except)

### DIFF
--- a/src/pygpt_net/controller/remote_store/remote_store.py
+++ b/src/pygpt_net/controller/remote_store/remote_store.py
@@ -151,7 +151,7 @@ class RemoteStore:
         if provider == "openai":
             self.window.controller.assistant.editor.update_store_list()  # update stores list in assistant dialog
 
-    def after_update(self, provider: str, store: RemoteStoreItem):
+    def after_update(self, provider: str, store: Optional[RemoteStoreItem] = None):
         """Hook: called after store update (per provider)."""
         if provider == "openai":
             self.window.controller.assistant.editor.update_store_list()


### PR DESCRIPTION
### Problem

`RemoteStore.update()` invokes the `after_update` provider hook with one argument:

https://github.com/szczyglis-dev/py-gpt/blob/master/src/pygpt_net/controller/remote_store/remote_store.py#L427-L434

```python
def update(self):
    """Refresh lists and auxiliary widgets."""
    self.reload_items()
    try:
        self.after_update(self._get_provider())
    except Exception:
        pass
    self.update_files_list()
```

but the hook takes two (`remote_store.py:154`):

```python
def after_update(self, provider: str, store: RemoteStoreItem):
    """Hook: called after store update (per provider)."""
    if provider == "openai":
        self.window.controller.assistant.editor.update_store_list()
```

so the call raises `TypeError: after_update() missing 1 required positional argument: 'store'`. The bare `except Exception: pass` swallows it, so there is no traceback and no log line — the hook body simply never runs. The visible effect is that the store list in the assistant editor dialog is not refreshed after `save()` (which ends in `self.update()`), nor after any of the ~15 other `update()` call sites, including the batch operations in `controller/remote_store/batch.py`.

The two sibling hooks in the same class are called correctly, which is what makes this one stand out:

| call site | call | hook signature | binds? |
|---|---|---|---|
| `remote_store.py:591` | `self.after_create(self._get_provider(), store)` | `(provider, store)` | ✅ |
| `remote_store.py:648` | `self.after_delete(self._get_provider(), sid)` | `(provider, store_id)` | ✅ |
| `remote_store.py:431` | `self.after_update(self._get_provider())` | `(provider, store)` | ❌ |

### Fix

`store` is not read anywhere in `after_update`'s body, and `update()` is a general refresh with no single store in scope (it is reached from batch import/truncate/delete paths as well as from `save()`), so the smallest fix that restores the hook without inventing a value is to give the parameter a default:

```python
-    def after_update(self, provider: str, store: RemoteStoreItem):
+    def after_update(self, provider: str, store: Optional[RemoteStoreItem] = None):
```

`Optional` is already imported in this module.

If you would rather keep `store` required and have the caller supply it, the alternative is to resolve the selected item in `update()` (`self._core_for().items.get(self.current)`) and pass that — happy to switch to that shape instead, just say which you prefer.

### Verification

Signature replay against the real source (`RemoteStore` methods extracted with `ast`, annotations/defaults stripped, then `inspect.Signature.bind`), with the two working siblings as a control group:

```
after_create(self, provider, store)      <- self.after_create(..., ...)  [line 591]  -> OK
after_delete(self, provider, store_id)   <- self.after_delete(..., ...)  [line 648]  -> OK
after_update(self, provider, store)      <- self.after_update(...)       [line 431]  -> TypeError: missing a required argument: 'store'
after_update(self, provider, store=None) <- self.after_update(...)       [patched]   -> OK
```

I don't have an OpenAI vector-store account wired up here, so I verified the call itself rather than watching the assistant dialog refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
