### PR TITLE
Add llmman as a local model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1161,6 +1161,7 @@ There is built-in support for those LLM providers:
 - `HuggingFace API`
 - `HuggingFace Router` (wrapper for OpenAI compatible ChatCompletions)
 - `LiteLLM`
+- `llmman`
 - `Local models` (OpenAI API compatible)
 - `Mistral AI`
 - `Ollama`
@@ -1230,6 +1231,18 @@ https://ollama.com/library
 https://github.com/ollama/ollama
 
 **IMPORTANT:** Remember to define the correct model name in the **kwargs list in the model settings.
+
+**Using llmman**
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port 17434. Models are pulled as OCI artifacts or straight from Hugging Face (`hf.co/org/model`) and served by `llama.cpp`, `vllm`, or `mlx-lm`. Select the `llmman` provider for a model (or import models from a running instance with `Config -> Models -> Import...`) and run:
+
+```curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh```
+
+```llmman serve```
+
+```llmman pull gemma4```
+
+The default endpoint is: http://localhost:17434 - override it with the `LLMMAN_HOST` environment variable (`[host][:port]`) in `Settings -> General -> Advanced -> Application environment`.
 
 **Using local embeddings**
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -124,6 +124,7 @@ There is built-in support for those LLM providers:
 * ``HuggingFace API``
 * ``HuggingFace Router`` (wrapper for OpenAI compatible ChatCompletions)
 * ``LiteLLM``
+* ``llmman``
 * ``Local models`` (OpenAI API compatible)
 * ``Mistral AI``
 * ``Ollama``
@@ -219,6 +220,18 @@ https://ollama.com/library
 https://github.com/ollama/ollama
 
 **IMPORTANT:** Remember to define the correct model name in the **kwargs list in the model settings.
+
+**Using llmman**
+
+`llmman <https://github.com/llmmanorg/llmman>`_ is a local model runner that serves the Ollama API (alongside OpenAI- and Anthropic-compatible ones) on port 17434. Models are pulled as OCI artifacts or straight from Hugging Face (``hf.co/org/model``) and served by ``llama.cpp``, ``vllm``, or ``mlx-lm``. Select the ``llmman`` provider for a model (or import models from a running instance with ``Config -> Models -> Import...``) and run:
+
+.. code-block:: sh
+
+    $ curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
+    $ llmman serve
+    $ llmman pull gemma4
+
+The default endpoint is: http://localhost:17434 - override it with the ``LLMMAN_HOST`` environment variable (``[host][:port]``) in ``Settings -> General -> Advanced -> Application environment``.
 
 Using local embeddings
 ```````````````````````

--- a/src/pygpt_net/app.py
+++ b/src/pygpt_net/app.py
@@ -276,6 +276,7 @@ def run(**kwargs):
         # from pygpt_net.provider.llms.hugging_face import HuggingFaceLLM
         from pygpt_net.provider.llms.hugging_face_api import HuggingFaceApiLLM
         from pygpt_net.provider.llms.hugging_face_router import HuggingFaceRouterLLM
+        from pygpt_net.provider.llms.llmman import LlmmanLLM
         from pygpt_net.provider.llms.local import LocalLLM
         from pygpt_net.provider.llms.mistral import MistralAILLM
         from pygpt_net.provider.llms.ollama import OllamaLLM
@@ -488,6 +489,7 @@ def run(**kwargs):
         launcher.add_llm(LocalLLM())
         launcher.add_llm(MistralAILLM())
         launcher.add_llm(OllamaLLM())
+        launcher.add_llm(LlmmanLLM())
         launcher.add_llm(DeepseekApiLLM())
         launcher.add_llm(PerplexityLLM())
         launcher.add_llm(xAILLM())

--- a/src/pygpt_net/core/models/models.py
+++ b/src/pygpt_net/core/models/models.py
@@ -528,6 +528,11 @@ class Models:
                 args["api_key"] = "ollama"
                 args["base_url"] = self.window.core.models.ollama.get_base_url() + "/v1"
                 self.window.core.debug.info("[api] Using client: Ollama")
+            elif model.provider == "llmman":
+                from pygpt_net.provider.llms.llmman import LlmmanLLM
+                args["api_key"] = "llmman"
+                args["base_url"] = LlmmanLLM.get_base_url() + "/v1"
+                self.window.core.debug.info("[api] Using client: llmman")
             else:
                 self.window.core.debug.info("[api] Using client: OpenAI (default)")
 

--- a/src/pygpt_net/core/types/openai.py
+++ b/src/pygpt_net/core/types/openai.py
@@ -15,6 +15,7 @@ OPENAI_COMPATIBLE_PROVIDERS = [
     "azure_openai",
     "google",
     "huggingface_router",
+    "llmman",
     "local_ai",
     "mistral_ai",
     "ollama",

--- a/src/pygpt_net/provider/api/reasoning.py
+++ b/src/pygpt_net/provider/api/reasoning.py
@@ -37,7 +37,7 @@ def is_tagged_reasoning_model(model) -> bool:
         pass
 
     provider = str(getattr(model, "provider", "") or "").strip().lower()
-    if provider == "local_ai":
+    if provider in ("local_ai", "llmman"):
         return True
 
     llama_cfg = getattr(model, "llama_index", None)

--- a/src/pygpt_net/provider/llms/llmman.py
+++ b/src/pygpt_net/provider/llms/llmman.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ================================================== #
+# This file is a part of PYGPT package               #
+# Website: https://pygpt.net                         #
+# GitHub:  https://github.com/szczyglis-dev/py-gpt   #
+# MIT License                                        #
+# Created By  : Marcin Szczygliński                  #
+# Updated Date: 2026.09.04 12:00:00                  #
+# ================================================== #
+
+import os
+from typing import Optional, List, Dict
+
+from llama_index.core.base.embeddings.base import BaseEmbedding
+
+from pygpt_net.provider.llms.ollama import OllamaLLM
+
+
+class LlmmanLLM(OllamaLLM):
+    """llmman - local model runner serving the Ollama API on port 17434: https://github.com/llmmanorg/llmman"""
+    def __init__(self, *args, **kwargs):
+        super(LlmmanLLM, self).__init__(*args, **kwargs)
+        self.id = "llmman"
+        self.name = "llmman"
+
+    @staticmethod
+    def get_base_url() -> str:
+        """
+        Get llmman API base URL (override with LLMMAN_HOST = [host][:port])
+
+        :return: llmman API base URL
+        """
+        host = os.environ.get("LLMMAN_HOST", "").strip()
+        if "://" in host:
+            return host.rstrip("/")
+        name, _, port = host.rpartition(":") if ":" in host else (host, "", "")
+        return f"http://{name or 'localhost'}:{port or 17434}"
+
+    def get_embeddings_model(
+            self,
+            window,
+            config: Optional[List[Dict]] = None
+    ) -> BaseEmbedding:
+        """
+        Return provider instance for embeddings (Ollama embeddings against the llmman URL)
+
+        :param window: window instance
+        :param config: config keyword arguments list
+        :return: Embedding provider instance
+        """
+        base_url = [{"name": "base_url", "value": self.get_base_url(), "type": "str"}]
+        return super().get_embeddings_model(window, base_url + (config or []))
+
+    def get_models(
+            self,
+            window,
+    ) -> List[Dict]:
+        """
+        Return list of models for the provider (via /v1/models, for the model importer)
+
+        :param window: window instance
+        :return: list of models
+        """
+        client = self.get_client(window)
+        return [{"id": item.id, "name": item.id} for item in client.models.list().data]

--- a/tests/provider/llms/test_llm_llmman.py
+++ b/tests/provider/llms/test_llm_llmman.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ================================================== #
+# This file is a part of PYGPT package               #
+# Website: https://pygpt.net                         #
+# GitHub:  https://github.com/szczyglis-dev/py-gpt   #
+# MIT License                                        #
+# Created By  : Marcin Szczygliński                  #
+# Updated Date: 2026.09.04 12:00:00                  #
+# ================================================== #
+
+from unittest.mock import MagicMock, patch
+
+from tests.mocks import mock_window
+from pygpt_net.provider.llms.llmman import LlmmanLLM as Wrapper
+
+
+def test_ids():
+    wrapper = Wrapper()
+    assert wrapper.id == "llmman"
+    assert wrapper.name == "llmman"
+
+
+def test_get_base_url():
+    with patch.dict("os.environ", {}, clear=True):
+        assert Wrapper.get_base_url() == "http://localhost:17434"
+    with patch.dict("os.environ", {"LLMMAN_HOST": "0.0.0.0:18000"}):
+        assert Wrapper.get_base_url() == "http://0.0.0.0:18000"
+    with patch.dict("os.environ", {"LLMMAN_HOST": "myhost"}):
+        assert Wrapper.get_base_url() == "http://myhost:17434"
+    with patch.dict("os.environ", {"LLMMAN_HOST": ":18000"}):
+        assert Wrapper.get_base_url() == "http://localhost:18000"
+
+
+def test_get_embeddings_model(mock_window):
+    wrapper = Wrapper()
+    with patch("llama_index.embeddings.ollama.OllamaEmbedding") as embedding, \
+            patch.dict("os.environ", {"OLLAMA_API_BASE": "http://ollama:11434"}, clear=True):
+        wrapper.get_embeddings_model(mock_window, [{"name": "model", "value": "gemma4", "type": "str"}])
+        kwargs = embedding.call_args.kwargs
+        assert kwargs["model_name"] == "gemma4"
+        assert kwargs["base_url"] == "http://localhost:17434"
+
+
+def test_get_models(mock_window):
+    wrapper = Wrapper()
+    client = MagicMock()
+    client.models.list.return_value.data = [MagicMock(id="gemma4"), MagicMock(id="qwen3.8")]
+    wrapper.get_client = MagicMock(return_value=client)
+    assert wrapper.get_models(mock_window) == [
+        {"id": "gemma4", "name": "gemma4"},
+        {"id": "qwen3.8", "name": "qwen3.8"},
+    ]


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API (plus OpenAI- and Anthropic-compatible ones) on port 17434.

- `provider/llms/llmman.py`: `LlmmanLLM(OllamaLLM)` - same protocol, so only the id/name and the default base URL (`http://localhost:17434`, overridable via `LLMMAN_HOST` as `[host][:port]`) differ. Embeddings are the inherited `OllamaEmbedding` pointed at that URL.
- `get_models()` lists models via `/v1/models` so `Config -> Models -> Import...` works; the built-in Ollama importer is hardwired to `OLLAMA_API_BASE`.
- `core/models/models.py` / `core/types/openai.py`: resolve `api_key`/`base_url` for `provider == "llmman"` and mark it OpenAI-compatible, used by Chat mode and the inherited `OllamaLLM.llama()` bridge.
- `provider/api/reasoning.py`: treat llmman like `local_ai` for `<think>` tag extraction.
- README / `docs/source/models.rst`: provider list entry and a short "Using llmman" section next to Ollama's.

**Testing:** `python -m py_compile` on touched files; new `tests/provider/llms/test_llm_llmman.py` (4 tests) and `tests/provider/llms/test_llm_ollama.py` pass. Not run against a live llmman server or the GUI.

> AI-assisted, reviewed before submitting.
