### PR TITLE
feat: add optional You.com search integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Release: **2.8.9** | build: **2026-09-05** | Python: **>=3.10, <3.14**
 
 **PyGPT** is an **all-in-one desktop AI assistant** supporting models from `OpenAI` (`GPT-5`, `GPT-4`, `o1`, `o3`), `Google Gemini`, `Anthropic Claude`, `xAI Grok`, `Perplexity / Sonar`, `DeepSeek`, and models available through `HuggingFace`, `LlamaIndex`, OpenAI-compatible APIs, and local `Ollama` installations such as `Gemma 4`, `Qwen 3.6`, `Llama 4`, `Mistral Small 3.2`, `DeepSeek`, `Bielik`, `Nemotron`, and `gpt-oss`.
 
-It supports chat, agents, completions, Chat with Files (via `LlamaIndex`), image and video generation, and image analysis. Models can work with files, run Python and system or custom commands, transfer files, call external APIs, and search the web with `DuckDuckGo`, `Google` and `Microsoft Bing`.
+It supports chat, agents, completions, Chat with Files (via `LlamaIndex`), image and video generation, and image analysis. Models can work with files, run Python and system or custom commands, transfer files, call external APIs, and search the web with `DuckDuckGo`, `Google`, `Microsoft Bing` and `You.com`.
 
 **PyGPT** also provides speech synthesis through `Microsoft Azure`, `Google`, `Eleven Labs` and `OpenAI`, plus speech recognition with `OpenAI Whisper`, `Google` and `Bing`. It stores conversation history and memory, supports reusable presets, and can be extended with built-in or custom plugins for tools, automation and external integrations.
 
@@ -44,7 +44,7 @@ You can download compiled 64-bit versions for Windows and Linux here: https://py
 - Built-in vector databases support and automated files and data embedding.
 - Image generation via models like `gpt-image`, `Imagen`, `Gemini`, and `Nano Banana`.
 - Video generation via models like `Veo3` and `Sora2`.
-- Internet access via `DuckDuckGo`, `Google` and `Microsoft Bing`.
+- Internet access via `DuckDuckGo`, `Google`, `Microsoft Bing` and `You.com`.
 - Speech synthesis via `Microsoft Azure`, `Google`, `Eleven Labs` and `OpenAI` Text-To-Speech services.
 - Speech recognition via `OpenAI Whisper`, `Google` and `Microsoft Speech Recognition`.
 - Plugins support with built-in plugins like `Files I/O`, `Code Interpreter`, `Web Search`, `Google`, `Facebook`, `X/Twitter`, `Slack`, `Telegram`, `GitHub`, `MCP`, and many more.
@@ -1888,7 +1888,7 @@ See the ``Accessibility`` section for more details.
 
 To activate this feature, turn on the `Web Search` plugin found in the `Plugins` menu.
 
-Web searches are provided by `Google Custom Search Engine` and `Microsoft Bing` APIs and can be extended with other search engine providers. 
+Web searches are provided by `DuckDuckGo`, `Google Custom Search Engine`, `Microsoft Bing` and `You.com` APIs and can be extended with other search engine providers. 
 
 Documentation: https://pygpt.readthedocs.io/en/latest/plugins.html#web-search
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -6,7 +6,7 @@ Overview
 
 **PyGPT** is an **all-in-one desktop AI assistant** supporting models from ``OpenAI`` (``GPT-5``, ``GPT-4``, ``o1``, ``o3``), ``Google Gemini``, ``Anthropic Claude``, ``xAI Grok``, ``Perplexity / Sonar``, ``DeepSeek``, and models available through ``HuggingFace``, ``LlamaIndex``, OpenAI-compatible APIs, and local ``Ollama`` installations such as ``Gemma 4``, ``Qwen 3.6``, ``Llama 4``, ``Mistral Small 3.2``, ``DeepSeek``, ``Bielik``, ``Nemotron``, and ``gpt-oss``.
 
-It supports chat, agents, completions, Chat with Files (via ``LlamaIndex``), image and video generation, and image analysis. Models can work with files, run Python and system or custom commands, transfer files, call external APIs, and search the web with ``DuckDuckGo``, ``Google`` and ``Microsoft Bing``.
+It supports chat, agents, completions, Chat with Files (via ``LlamaIndex``), image and video generation, and image analysis. Models can work with files, run Python and system or custom commands, transfer files, call external APIs, and search the web with ``DuckDuckGo``, ``Google``, ``Microsoft Bing`` and ``You.com``.
 
 **PyGPT** also provides speech synthesis through ``Microsoft Azure``, ``Google``, ``Eleven Labs`` and ``OpenAI``, plus speech recognition with ``OpenAI Whisper``, ``Google`` and ``Bing``. It stores conversation history and memory, supports reusable presets, and can be extended with built-in or custom plugins for tools, automation and external integrations.
 
@@ -31,7 +31,7 @@ Features
 * Built-in vector databases support and automated files and data embedding.
 * Image generation via models like ``gpt-image``, ``Imagen``, ``Gemini`` and ``Nano Banana``.
 * Video generation via models like ``Veo3`` and ``Sora2``.
-* Internet access via ``DuckDuckGo``, ``Google`` and ``Microsoft Bing``.
+* Internet access via ``DuckDuckGo``, ``Google``, ``Microsoft Bing`` and ``You.com``.
 * Speech synthesis via ``Microsoft Azure``, ``Google``, ``Eleven Labs`` and ``OpenAI`` Text-To-Speech services.
 * Speech recognition via ``OpenAI Whisper``, ``Google`` and ``Microsoft Speech Recognition``.
 * Plugins support with built-in plugins like ``Files I/O``, ``Code Interpreter``, ``Web Search``, ``Google``, ``Facebook``, ``X/Twitter``, ``Slack``, ``Telegram``, ``GitHub``, ``MCP``, and many more.

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -2857,7 +2857,7 @@ Web Search
 
 To activate this feature, turn on the ``Web Search`` plugin found in the ``Plugins`` menu.
 
-Web searches are provided by ``DuckDuckGo``, ``Google Custom Search Engine`` and ``Microsoft Bing`` APIs and can be extended with other search engine providers. 
+Web searches are provided by ``DuckDuckGo``, ``Google Custom Search Engine``, ``Microsoft Bing`` and ``You.com`` APIs and can be extended with other search engine providers. 
 
 **Options**
 
@@ -2869,6 +2869,7 @@ Available providers:
 
 - Google
 - Microsoft Bing
+- You.com
 
 **Google**
 
@@ -2907,6 +2908,16 @@ You can obtain your own API key at https://www.microsoft.com/en-us/bing/apis/bin
 - ``Bing Search API endpoint`` *bing_endpoint*
 
 API endpoint for Bing Search API, default: https://api.bing.microsoft.com/v7.0/search
+
+**You.com**
+
+- ``You.com API KEY`` *youcom_api_key*
+
+Optional. You can obtain your own API key at https://you.com/platform/api-keys - if left empty, the keyless endpoint is used.
+
+- ``You.com MCP endpoint`` *youcom_endpoint*
+
+You.com MCP endpoint, default: https://api.you.com/mcp?profile=free (keyless); use https://api.you.com/mcp with an API key.
 
 **General options**
 

--- a/src/pygpt_net/app.py
+++ b/src/pygpt_net/app.py
@@ -345,6 +345,7 @@ def run(**kwargs):
         from pygpt_net.provider.web.google_custom_search import GoogleCustomSearch
         from pygpt_net.provider.web.microsoft_bing import MicrosoftBingSearch
         from pygpt_net.provider.web.duckduck_search import DuckDuckGoSearch
+        from pygpt_net.provider.web.youcom_search import YouComSearch
 
         # tools
         from pygpt_net.tools.indexer import IndexerTool
@@ -390,6 +391,7 @@ def run(**kwargs):
         launcher.add_web(GoogleCustomSearch())
         launcher.add_web(MicrosoftBingSearch())
         launcher.add_web(DuckDuckGoSearch())
+        launcher.add_web(YouComSearch())
 
         # register custom web providers
         providers = kwargs.get('web', None)

--- a/src/pygpt_net/provider/web/youcom_search.py
+++ b/src/pygpt_net/provider/web/youcom_search.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ================================================== #
+# This file is a part of PYGPT package               #
+# Website: https://pygpt.net                         #
+# GitHub:  https://github.com/szczyglis-dev/py-gpt   #
+# MIT License                                        #
+# Created By  : Marcin Szczygliński                  #
+# Updated Date: 2026.09.05 18:00:00                  #
+# ================================================== #
+
+import json
+from typing import List, Dict
+
+import requests
+
+from .base import BaseProvider
+
+
+class YouComSearch(BaseProvider):
+    # default keyless endpoint, used when the endpoint option is not set
+    DEFAULT_ENDPOINT = "https://api.you.com/mcp?profile=free"
+
+    def __init__(self, *args, **kwargs):
+        """
+        You.com Search provider
+
+        :param args: args
+        :param kwargs: kwargs
+        """
+        super(YouComSearch, self).__init__(*args, **kwargs)
+        self.plugin = kwargs.get("plugin")
+        self.id = "youcom_search"
+        self.name = "You.com"
+        self.type = ["search_engine"]
+
+    def init_options(self):
+        """Initialize options"""
+        url_api = {
+            "API Key": "https://you.com/platform/api-keys",
+        }
+        self.plugin.add_option(
+            "youcom_api_key",
+            type="text",
+            value="",
+            label="You.com API KEY",
+            description="Optional. You can obtain your own API key at "
+                        "https://you.com/platform/api-keys - if left empty, the keyless endpoint is used",
+            tooltip="You.com API KEY",
+            secret=True,
+            persist=True,
+            tab="youcom_search",
+            urls=url_api,
+        )
+        self.plugin.add_option(
+            "youcom_endpoint",
+            type="text",
+            value="https://api.you.com/mcp?profile=free",
+            label="You.com MCP endpoint",
+            description="You.com MCP endpoint, default: https://api.you.com/mcp?profile=free (keyless); "
+                        "use https://api.you.com/mcp with an API key",
+            tooltip="You.com MCP endpoint",
+            persist=False,
+            tab="youcom_search",
+        )
+
+    def search(
+            self,
+            query: str,
+            limit: int = 10,
+            offset: int = 0
+    ) -> List[str]:
+        """
+        Execute search query and return list of urls
+
+        :param query: query
+        :param limit: limit
+        :param offset: offset
+        :return: list of urls
+        """
+        urls = []
+
+        if limit < 1:
+            limit = 1
+        if limit > 10:
+            limit = 10
+
+        if limit + offset > 100:
+            limit = 100 - offset
+
+        try:
+            # fetch enough results to cover the requested offset + limit
+            target = limit + offset
+            collected = self._fetch(query, target)
+            if offset > 0:
+                collected = collected[offset:offset + limit]
+            else:
+                collected = collected[:limit]
+
+            # de-dup and keep order
+            seen = set()
+            for u in collected:
+                if u and u not in seen:
+                    urls.append(u)
+                    seen.add(u)
+
+        except Exception as e:
+            # fail safe: never raise to the app layer
+            print(e)
+
+        return urls
+
+    def _fetch(self, query: str, count: int) -> List[str]:
+        """
+        Call You.com MCP server (you-search tool) and return list of urls
+
+        :param query: query
+        :param count: number of results to fetch
+        :return: list of urls
+        """
+        endpoint = str(self.plugin.get_option_value("youcom_endpoint") or self.DEFAULT_ENDPOINT)
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "you-search",
+                "arguments": {
+                    "query": query,
+                },
+            },
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        }
+        key = self.get_key()
+        if key:
+            # authenticated endpoint takes precedence over the keyless one
+            headers["Authorization"] = "Bearer " + key
+        response = requests.post(
+            endpoint,
+            json=payload,
+            headers=headers,
+            timeout=30,
+        )
+        if response.status_code != 200:
+            print('You.com search error:', response.status_code, response.text)
+            return []
+
+        # the endpoint answers with SSE stream (text/event-stream) or plain JSON
+        data = self._parse_response(response)
+        results = data.get("results", {})
+        urls: List[str] = []
+        for item in results.get("web", []):
+            url = item.get("url")
+            if url:
+                urls.append(url)
+            if len(urls) >= count:
+                break
+        return urls
+
+    def _parse_response(self, response) -> dict:
+        """
+        Parse MCP response and return the result data dict
+
+        :param response: HTTP response
+        :return: result data dict
+        """
+        content_type = response.headers.get("Content-Type", "")
+        body = response.text
+        if "text/event-stream" in content_type:
+            # take the last data line that holds the JSON-RPC result
+            for line in reversed(body.splitlines()):
+                line = line.strip()
+                if line.startswith("data:"):
+                    body = line[len("data:"):].strip()
+                    break
+        envelope = json.loads(body)
+        if "error" in envelope and envelope["error"] is not None:
+            print('You.com search error:', envelope["error"])
+            return {}
+        result = envelope.get("result", {})
+        for item in result.get("content", []):
+            if item.get("type") == "text":
+                try:
+                    return json.loads(item.get("text", "{}"))
+                except (ValueError, TypeError):
+                    return {}
+        return {}
+
+    def is_configured(self, cmds: List[Dict]) -> bool:
+        """
+        Check if provider is configured (required API keys, etc.)
+
+        :param cmds: executed commands list
+        :return: True if configured, False if configuration is missing
+        """
+        # the default (keyless) endpoint requires no API key
+        endpoint = str(self.plugin.get_option_value("youcom_endpoint") or self.DEFAULT_ENDPOINT)
+        if "profile=free" in endpoint:
+            return True
+        key = self.get_key()
+        return key is not None and key != ""
+
+    def get_config_message(self) -> str:
+        """
+        Return message to display when provider is not configured
+
+        :return: message
+        """
+        return ("You.com API key is not set. Please set the API key in plugin settings "
+                "or switch the endpoint back to the keyless https://api.you.com/mcp?profile=free")
+
+    def get_key(self) -> str:
+        """
+        Return You.com API key
+
+        :return: You.com API key
+        """
+        key = self.plugin.get_option_value("youcom_api_key")
+        if key is None or str(key) == "":
+            import os
+            key = os.environ.get("YDC_API_KEY", "")
+        return str(key)

--- a/tests/provider/web/test_youcom_search.py
+++ b/tests/provider/web/test_youcom_search.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ================================================== #
+# This file is a part of PYGPT package               #
+# Website: https://pygpt.net                         #
+# GitHub:  https://github.com/szczyglis-dev/py-gpt   #
+# MIT License                                        #
+# Created By  : Marcin Szczygliński                  #
+# Updated Date: 2026.09.05 18:00:00                  #
+# ================================================== #
+
+import json
+from unittest.mock import MagicMock
+
+from pygpt_net.provider.web.youcom_search import YouComSearch
+
+
+def make_plugin(options: dict = None) -> MagicMock:
+    """Build a minimal plugin mock with options dict"""
+    if options is None:
+        options = {}
+    plugin = MagicMock()
+
+    def add_option(name, type=None, **kwargs):
+        option = dict(kwargs)
+        option["id"] = name
+        option["type"] = type
+        options[name] = option
+        return option
+
+    def get_option_value(name):
+        return options.get(name)
+
+    plugin.add_option = add_option
+    plugin.get_option_value = get_option_value
+    plugin.options = options
+    return plugin
+
+
+def make_response(status_code: int = 200, body: str = "", content_type: str = "application/json") -> MagicMock:
+    """Build a minimal HTTP response mock"""
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = body
+    response.headers = {"Content-Type": content_type}
+    return response
+
+
+def mcp_body(results: dict) -> str:
+    """Build a JSON-RPC tools/call response body with given results"""
+    return json.dumps({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps({"results": results}),
+                }
+            ]
+        },
+    })
+
+
+def test_options():
+    """Test provider options"""
+    plugin = make_plugin()
+    provider = YouComSearch(plugin=plugin)
+    provider.init_options()
+    assert "youcom_api_key" in plugin.options
+    assert "youcom_endpoint" in plugin.options
+    assert plugin.options["youcom_endpoint"]["value"] == "https://api.you.com/mcp?profile=free"
+
+
+def test_ids():
+    """Test provider id and type"""
+    plugin = make_plugin()
+    provider = YouComSearch(plugin=plugin)
+    assert provider.id == "youcom_search"
+    assert provider.name == "You.com"
+    assert provider.type == ["search_engine"]
+
+
+def test_search_parses_urls():
+    """Test parsing URLs from MCP response"""
+    plugin = make_plugin()
+    provider = YouComSearch(plugin=plugin)
+    body = mcp_body({
+        "web": [
+            {"url": "https://example.com/1", "title": "one"},
+            {"url": "https://example.com/2", "title": "two"},
+        ],
+    })
+    provider._fetch = MagicMock(return_value=[
+        "https://example.com/1",
+        "https://example.com/2",
+    ])
+    # direct parse check
+    data = provider._parse_response(make_response(body=body))
+    urls = [item.get("url") for item in data["results"]["web"]]
+    assert urls == ["https://example.com/1", "https://example.com/2"]
+
+
+def test_parse_response_sse():
+    """Test parsing SSE stream response"""
+    plugin = make_plugin()
+    provider = YouComSearch(plugin=plugin)
+    body = mcp_body({"web": [{"url": "https://example.com/sse"}]})
+    sse = 'event: message\n' + "data: " + body + "\n\n"
+    data = provider._parse_response(make_response(body=sse, content_type="text/event-stream"))
+    assert data["results"]["web"][0]["url"] == "https://example.com/sse"
+
+
+def test_parse_response_error_envelope():
+    """Test parsing JSON-RPC error envelope"""
+    plugin = make_plugin()
+    provider = YouComSearch(plugin=plugin)
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "error": {"code": -32000, "message": "err"}})
+    data = provider._parse_response(make_response(body=body))
+    assert data == {}
+
+
+def test_fetch_request_construction(monkeypatch):
+    """Test request construction: endpoint, payload, headers"""
+    plugin = make_plugin({
+        "youcom_endpoint": "https://api.you.com/mcp?profile=free",
+        "youcom_api_key": "",
+    })
+    provider = YouComSearch(plugin=plugin)
+    captured = {}
+
+    def fake_post(endpoint, json=None, headers=None, timeout=None):
+        captured["endpoint"] = endpoint
+        captured["json"] = json
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return make_response(body=mcp_body({"web": [{"url": "https://example.com/a"}]}))
+
+    monkeypatch.setattr("pygpt_net.provider.web.youcom_search.requests.post", fake_post)
+    urls = provider._fetch("test query", 10)
+    assert urls == ["https://example.com/a"]
+    assert captured["endpoint"] == "https://api.you.com/mcp?profile=free"
+    assert captured["json"]["method"] == "tools/call"
+    assert captured["json"]["params"]["name"] == "you-search"
+    assert captured["json"]["params"]["arguments"]["query"] == "test query"
+    assert "Authorization" not in captured["headers"]
+
+
+def test_fetch_with_api_key_uses_bearer(monkeypatch):
+    """Test that API key is sent as bearer token"""
+    plugin = make_plugin({
+        "youcom_endpoint": "https://api.you.com/mcp",
+        "youcom_api_key": "test-key",
+    })
+    provider = YouComSearch(plugin=plugin)
+    captured = {}
+
+    def fake_post(endpoint, json=None, headers=None, timeout=None):
+        captured["headers"] = headers
+        return make_response(body=mcp_body({"web": [{"url": "https://example.com/b"}]}))
+
+    monkeypatch.setattr("pygpt_net.provider.web.youcom_search.requests.post", fake_post)
+    provider._fetch("q", 10)
+    assert captured["headers"]["Authorization"] == "Bearer test-key"
+
+
+def test_fetch_http_error_returns_empty(monkeypatch):
+    """Test fail-safe on HTTP error"""
+    plugin = make_plugin({})
+    provider = YouComSearch(plugin=plugin)
+    response = make_response(status_code=500, body="err")
+    monkeypatch.setattr(
+        "pygpt_net.provider.web.youcom_search.requests.post",
+        MagicMock(return_value=response),
+    )
+    assert provider._fetch("q", 10) == []
+
+
+def test_search_fail_safe_on_exception():
+    """Test search never raises to the app layer"""
+    plugin = make_plugin({})
+    provider = YouComSearch(plugin=plugin)
+    provider._fetch = MagicMock(side_effect=Exception("network down"))
+    assert provider.search("q", 10) == []
+
+
+def test_search_limit_offset():
+    """Test limit and offset handling"""
+    plugin = make_plugin({})
+    provider = YouComSearch(plugin=plugin)
+    web = [{"url": "https://example.com/" + str(i)} for i in range(10)]
+    provider._fetch = MagicMock(return_value=[item["url"] for item in web])
+    assert len(provider.search("q", 3)) == 3
+    urls = provider.search("q", 3, offset=5)
+    assert urls == ["https://example.com/5", "https://example.com/6", "https://example.com/7"]
+
+
+def test_search_dedup():
+    """Test de-duplication of urls"""
+    plugin = make_plugin({})
+    provider = YouComSearch(plugin=plugin)
+    provider._fetch = MagicMock(return_value=[
+        "https://example.com/1",
+        "https://example.com/1",
+        "https://example.com/2",
+    ])
+    assert provider.search("q", 10) == ["https://example.com/1", "https://example.com/2"]
+
+
+def test_is_configured_keyless():
+    """Test keyless endpoint is always configured"""
+    plugin = make_plugin({"youcom_endpoint": "https://api.you.com/mcp?profile=free"})
+    provider = YouComSearch(plugin=plugin)
+    assert provider.is_configured([{"cmd": "web_search"}]) is True
+
+
+def test_is_configured_auth_requires_key():
+    """Test authenticated endpoint requires key"""
+    plugin = make_plugin({"youcom_endpoint": "https://api.you.com/mcp"})
+    provider = YouComSearch(plugin=plugin)
+    provider.get_key = MagicMock(return_value="")
+    assert provider.is_configured([{"cmd": "web_search"}]) is False
+    provider.get_key = MagicMock(return_value="key")
+    assert provider.is_configured([{"cmd": "web_search"}]) is True
+
+
+def test_get_key_from_env():
+    """Test API key fallback to YDC_API_KEY env var"""
+    import os
+    plugin = make_plugin({"youcom_api_key": ""})
+    provider = YouComSearch(plugin=plugin)
+    os.environ["YDC_API_KEY"] = "env-key"
+    try:
+        assert provider.get_key() == "env-key"
+    finally:
+        del os.environ["YDC_API_KEY"]
+    assert provider.get_key() == ""
+
+
+def test_get_config_message():
+    """Test config message"""
+    plugin = make_plugin({})
+    provider = YouComSearch(plugin=plugin)
+    assert "You.com API key" in provider.get_config_message()


### PR DESCRIPTION
This adds **You.com** as an optional web search engine provider for the Web Search plugin, following the existing provider pattern (`GoogleCustomSearch`, `MicrosoftBingSearch`, `DuckDuckGoSearch` in `pygpt_net/provider/web/`).

## What changed

- `src/pygpt_net/provider/web/youcom_search.py` — new `YouComSearch` provider implementing `BaseProvider`, registered alongside the built-in providers in `app.py`
- `tests/provider/web/test_youcom_search.py` — unit tests (request construction, SSE/JSON response parsing, limit/offset, de-dup, fail-safe on errors, `is_configured` behavior, env var fallback)
- Docs: provider list + option reference in `README.md`, `docs/source/intro.rst`, `docs/source/plugins.rst`

## Why

The docs note the Web Search plugin "can be extended with other search engine providers" — this adds one more option through that existing extension point. The provider calls the You.com MCP server's `you-search` tool over plain HTTPS using the repo's existing `requests` dependency. **No new dependencies.**

## Setup

Select `You.com` in the Web Search plugin's `Provider` option. It works **keyless out of the box** — the default endpoint (`https://api.you.com/mcp?profile=free`) needs no credentials. Optionally, a `You.com API KEY` can be set in the plugin settings (or via the `YDC_API_KEY` env var as a fallback); when a key is present, requests switch to the authenticated endpoint `https://api.you.com/mcp` with bearer auth. The endpoint is also overridable in settings, like `bing_endpoint`.

## Behavior / fail-safe

- Opt-in: only active when selected as the provider — default provider (`google_custom_search`) and all existing providers are untouched
- `is_configured` returns `True` for the keyless endpoint; the authenticated endpoint requires the key, otherwise the standard "set API key in plugin settings" flow kicks in
- HTTP errors, JSON-RPC error envelopes, and exceptions return an empty URL list (matching the DuckDuckGo provider's never-raise pattern) — the plugin then tries the next step as usual

## Validation

- `pytest tests/provider/web/ tests/plugin/cmd_web/` — 20/20 pass
- flake8 clean on both new files (`--max-line-length=120`)
- Live keyless end-to-end check of the provider's real HTTP path against `https://api.you.com/mcp?profile=free` (returns URLs, offset pagination works)
- Registration verified through the real `Web.register()` path: `youcom_search` shows up in the provider combo and settings tabs, defaults unchanged
- Full-suite collection errors in this environment are pre-existing (missing optional deps like `llama_index`, `speech_recognition`) and identical on unmodified `master`

Happy to adjust the shape if you'd prefer the provider under a different name/id or a different option layout.
